### PR TITLE
Fix ThemeManager bug

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -16,7 +16,8 @@ from PIL import Image
 # Add the parent directory to the Python path to resolve the 'src' module
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
-from themes import themes  # Import the themes
+from themes import themes  # Built-in themes
+from theme_manager import ThemeManager
 
 def get_int(config, section, key, fallback):
     val = config.get(section, key, fallback=fallback)
@@ -35,6 +36,9 @@ class ClipboardLoggerGUI:
             self.config_dir = os.path.join(self.base_dir, 'config')
             self.config_path = os.path.join(self.config_dir, 'config.ini')
             self.log_path = os.path.join(self.base_dir, 'clipboard_log.txt')
+
+            # Theme manager handles both built-in and user-defined themes
+            self.theme_manager = ThemeManager(os.path.join(self.base_dir, 'themes'))
 
             # Create required directories
             os.makedirs(self.config_dir, exist_ok=True)
@@ -123,7 +127,8 @@ class ClipboardLoggerGUI:
 
     def load_theme(self):
         theme_name = self.config.get('UI', 'theme', fallback='default')
-        self.current_theme = themes.get(theme_name, themes['default'])
+        available = self.theme_manager.get_all_themes()
+        self.current_theme = available.get(theme_name, available['default'])
         self.root.configure(bg=self.current_theme['bg'])
 
     def setup_styles(self):
@@ -165,7 +170,7 @@ class ClipboardLoggerGUI:
             self.menu_bar.add_cascade(label="File", menu=self.file_menu)
 
             self.theme_menu = tk.Menu(self.menu_bar, tearoff=0)
-            for theme_name, theme in themes.items():
+            for theme_name, theme in self.theme_manager.get_all_themes().items():
                 self.theme_menu.add_command(label=theme['name'], command=lambda t=theme: self.apply_theme(t))
             self.menu_bar.add_cascade(label="Themes", menu=self.theme_menu)
 
@@ -293,7 +298,13 @@ class ClipboardLoggerGUI:
                 logging.error(f"Error logging clipboard: {e}")
 
     def open_settings(self):
-        SettingsWindow(self.root, self.config, self.apply_theme, self.update_max_db_size)
+        SettingsWindow(
+            self.root,
+            self.config,
+            self.apply_theme,
+            self.update_max_db_size,
+            self.theme_manager,
+        )
 
     def save_settings(self):
         try:
@@ -308,8 +319,12 @@ class ClipboardLoggerGUI:
             with open(self.config_path, 'w', encoding='utf-8') as configfile:
                 self.config.write(configfile)
 
-            selected_theme = themes.get(self.theme_var.get(), themes['default'])
-            self.apply_theme_func(selected_theme)
+            self.theme_manager.reload()
+            selected = self.theme_manager.get_all_themes().get(
+                self.theme_var.get(),
+                self.theme_manager.get_all_themes()['default']
+            )
+            self.apply_theme_func(selected)
         except ValueError:
             messagebox.showerror("Error", "Invalid database size. Please enter a number.")
         except Exception as e:
@@ -419,20 +434,22 @@ class EditClipDialog(simpledialog.Dialog):
         self.ok()
 
 class SettingsWindow(tk.Toplevel):
-    def __init__(self, parent, config, apply_theme_func, update_max_db_size_func):
+    def __init__(self, parent, config, apply_theme_func, update_max_db_size_func, theme_manager: ThemeManager):
         super().__init__(parent)
         self.title("Settings")
         self.config = config
         self.apply_theme_func = apply_theme_func
         self.update_max_db_size_func = update_max_db_size_func
-        self.theme = themes['default']
+        self.theme_manager = theme_manager
+        self.theme = self.theme_manager.get_all_themes()['default']
         self.setup_ui()
 
     def setup_ui(self):
         theme_label = ttk.Label(self, text="Theme:")
         theme_label.grid(row=0, column=0, padx=5, pady=5)
         self.theme_var = tk.StringVar(value=self.config.get('UI', 'theme', fallback='default'))
-        theme_dropdown = ttk.Combobox(self, textvariable=self.theme_var, values=list(themes.keys()))
+        available = list(self.theme_manager.get_all_themes().keys())
+        theme_dropdown = ttk.Combobox(self, textvariable=self.theme_var, values=available)
         theme_dropdown.grid(row=0, column=1, padx=5, pady=5)
 
         dark_mode_label = ttk.Label(self, text="Dark Mode:")
@@ -475,8 +492,7 @@ class SettingsWindow(tk.Toplevel):
 
     def open_theme_creator(self):
         from theme_creator import ThemeCreator
-        themes_dir = os.path.join(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')), "themes")
-        ThemeCreator(self, themes_dir)
+        ThemeCreator(self, self.theme_manager.themes_dir, self.theme_manager)
 
     def save_settings(self):
         try:
@@ -491,8 +507,12 @@ class SettingsWindow(tk.Toplevel):
             with open(self.config_path, 'w', encoding='utf-8') as configfile:
                 self.config.write(configfile)
 
-            selected_theme = themes.get(self.theme_var.get(), themes['default'])
-            self.apply_theme_func(selected_theme)
+            self.theme_manager.reload()
+            selected = self.theme_manager.get_all_themes().get(
+                self.theme_var.get(),
+                self.theme_manager.get_all_themes()['default']
+            )
+            self.apply_theme_func(selected)
         except ValueError:
             messagebox.showerror("Error", "Invalid database size. Please enter a number.")
         except configparser.Error as e:

--- a/src/theme_creator.py
+++ b/src/theme_creator.py
@@ -5,10 +5,11 @@ import os
 import logging
 
 class ThemeCreator(tk.Toplevel):
-    def __init__(self, master, themes_dir):
+    def __init__(self, master, themes_dir, manager=None):
         super().__init__(master)
         self.title("Custom Theme Creator")
         self.themes_dir = themes_dir
+        self.manager = manager
         self.setup_ui()
 
     def setup_ui(self):
@@ -57,9 +58,12 @@ class ThemeCreator(tk.Toplevel):
                 "button_bg": self.colors["button_bg"],
                 "button_fg": self.colors["button_fg"]
             }
-            theme_path = os.path.join(self.themes_dir, f"{theme_name}.json")
-            with open(theme_path, "w") as f:
-                json.dump(theme_data, f, indent=4)
+            if self.manager:
+                self.manager.save_theme(theme_name, theme_data)
+            else:
+                theme_path = os.path.join(self.themes_dir, f"{theme_name}.json")
+                with open(theme_path, "w") as f:
+                    json.dump(theme_data, f, indent=4)
             messagebox.showinfo("Success", "Theme saved successfully!")
             self.destroy()
         except Exception as e:

--- a/src/theme_manager.py
+++ b/src/theme_manager.py
@@ -1,12 +1,29 @@
 import json
-import os
 from pathlib import Path
 
+# Import the predefined themes packaged with the application
+from themes import themes as built_in_themes
+
+
 class ThemeManager:
-    def __init__(self):
-        self.themes_dir = Path("themes")
+    """Manage built-in and user-defined themes.
+
+    The manager loads predefined themes from :mod:`themes` and merges them with
+    any custom themes stored on disk.  It also exposes helper methods for
+    creating, deleting and exporting themes.
+    """
+
+    def __init__(self, themes_dir: Path | str = "themes"):
+        self.themes_dir = Path(themes_dir)
         self.themes_dir.mkdir(exist_ok=True)
-        self.custom_themes = {}
+
+        # Themes that ship with the application remain immutable so we keep a
+        # dedicated dictionary for them.
+        self.built_in_themes: dict[str, dict] = built_in_themes
+
+        # Custom themes persisted to ``themes_dir``.
+        self.custom_themes: dict[str, dict] = {}
+
         self.load_custom_themes()
 
     def load_custom_themes(self):
@@ -15,18 +32,69 @@ class ThemeManager:
                 theme = json.load(f)
                 self.custom_themes[theme["name"]] = theme
 
+    def reload(self) -> None:
+        """Reload custom themes from disk."""
+        self.custom_themes.clear()
+        self.load_custom_themes()
+
     def save_theme(self, name, colors):
         theme = {
             "name": name,
             "colors": colors,
             "custom": True
         }
-        
+
         with open(self.themes_dir / f"{name}.json", "w") as f:
             json.dump(theme, f, indent=4)
-            
+
         self.custom_themes[name] = theme
         return theme
+
+    def delete_theme(self, name: str) -> bool:
+        """Remove a theme file and its cached entry.
+
+        Parameters
+        ----------
+        name: str
+            Name of the theme to remove.
+
+        Returns
+        -------
+        bool
+            ``True`` if a theme was deleted.
+        """
+        path = self.themes_dir / f"{name}.json"
+        if path.exists():
+            path.unlink()
+            self.custom_themes.pop(name, None)
+            return True
+        return False
+
+    def rename_theme(self, old_name: str, new_name: str) -> bool:
+        """Rename a custom theme on disk and in memory."""
+        old_path = self.themes_dir / f"{old_name}.json"
+        new_path = self.themes_dir / f"{new_name}.json"
+        if not old_path.exists() or new_path.exists():
+            return False
+        old_path.rename(new_path)
+        theme = self.custom_themes.pop(old_name)
+        theme["name"] = new_name
+        self.custom_themes[new_name] = theme
+        return True
+
+    def export_themes(self, export_path: Path | str) -> None:
+        """Export all themes to a single JSON file."""
+        data = self.get_all_themes()
+        with open(export_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+
+    def import_theme(self, path: Path | str) -> dict:
+        """Load a theme from a JSON file and save it as a custom theme."""
+        with open(path, "r", encoding="utf-8") as f:
+            theme = json.load(f)
+        name = theme["name"]
+        colors = theme.get("colors") or {k: v for k, v in theme.items() if k != "name"}
+        return self.save_theme(name, colors)
 
     def get_all_themes(self):
         return {**self.built_in_themes, **self.custom_themes}


### PR DESCRIPTION
## Summary
- load built-in themes in `ThemeManager`
- store built-in themes so `get_all_themes` works
- integrate `ThemeManager` with GUI and settings
- allow creating, deleting, renaming, exporting and importing themes
- ensure new themes appear in UI menus

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_683f829e3d448331aa6abe5873052225